### PR TITLE
Fixed disappearing routes

### DIFF
--- a/libs/time-to-read/src/lib/time-to-read.ts
+++ b/libs/time-to-read/src/lib/time-to-read.ts
@@ -9,9 +9,8 @@ export interface timeToReadOptions {
 export const timeToReadFunc = async (routes: HandledRoute[]) => {
   const options: timeToReadOptions = getMyConfig(timeToReadFunc);
   return routes
-    .filter((route) => route.templateFile)
     .map((route) => {
-      if (route.route.startsWith(options.path)) {
+      if (route.templateFile && route.route.startsWith(options.path)) {
         const content = fs.readFileSync(route.templateFile).toString('utf-8');
         const stats = readingTime(content);
         const newRoute = {


### PR DESCRIPTION
All routes must be returned - does not matter if with or without reading time. As it is now implemnted - some routes are not rendered at all.